### PR TITLE
Feature: Strip domain if stripdomain config is enabled

### DIFF
--- a/action.php
+++ b/action.php
@@ -45,6 +45,10 @@ class action_plugin_oauthazure extends Adapter
         $data['mail'] = $result['email'];
         $data['grps'] = array_merge($result['groups'] ?? [], $result['roles'] ?? []);
 
+        if ($this->getConf('stripdomain')) {
+            $data['user'] = explode('@', $data['user'], 2)[0];
+        }
+
         if ($this->getConf('fetchgroups')) {
             $usergroups = $oauth->request(Azure::GRAPH_MEMBEROF);
             $usergroups = json_decode($usergroups, true);

--- a/conf/default.php
+++ b/conf/default.php
@@ -8,3 +8,4 @@ $conf['key'] = '';
 $conf['secret'] = '';
 $conf['tenant'] = '';
 $conf['fetchgroups'] = 0;
+$conf['stripdomain'] = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -8,3 +8,4 @@ $meta['key'] = array('string');
 $meta['secret'] = array('password');
 $meta['tenant'] = array('string');
 $meta['fetchgroups'] = array('onoff');
+$meta['stripdomain'] = array('onoff');

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -8,3 +8,4 @@ $lang['key'] = 'Client ID';
 $lang['secret'] = 'Cient Secret';
 $lang['openidurl'] = 'Your tenant name or ID';
 $lang['fetchgroups'] = 'By default only roles from the JWT are used as user groups. Enabling this option fetches group data.';
+$lang['stripdomain'] = 'Strip @domain from preferred_username';


### PR DESCRIPTION
This is configurable via `stripdomain` option.

This is to overcome the problem that Azure returns email as `preferred_username`, which makes dokuwiki to create `glen_domain_tld` accounts:
- https://github.com/dokuwiki/dokuwiki/issues/3952