### PR TITLE
Add support for domain_hint

### DIFF
--- a/Azure.php
+++ b/Azure.php
@@ -61,7 +61,12 @@ class Azure extends AbstractOAuth2Base
     /** @inheritdoc */
     public function getAuthorizationEndpoint()
     {
-        return new Uri($this->getEndpoint(self::ENDPOINT_AUTH));
+        global $conf;
+        $uri = new Uri($this->getEndpoint(self::ENDPOINT_AUTH));
+        if (isset($conf['plugin']['oauth']['mailRestriction'])) {
+            $uri->addToQuery('domain_hint', substr($conf['plugin']['oauth']['mailRestriction'], 1));
+        }
+        return $uri;
     }
 
     /** @inheritdoc */


### PR DESCRIPTION
When "mailRestriction" is set, the "domain_hint" URI parameters shows only currently logged in accounts that belongs to the domain specified if user is connected to multiple Azure accounts of different domains.